### PR TITLE
chore: Update patched Agave dependencies to 1.18.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ incremental = false
 codegen-units = 1
 
 [patch.crates-io]
-"solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-accounts-db" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-banks-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-banks-interface" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-banks-server" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-program" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-cli-output" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-program-test" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-program-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-rpc" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-rpc-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-rpc-client-api" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-sdk-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-zk-token-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-frozen-abi" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-frozen-abi-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-transaction-status" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
+"solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-accounts-db" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-banks-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-banks-interface" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-banks-server" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-program" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-cli-output" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-program-test" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-program-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-rpc" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-rpc-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-rpc-client-api" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-sdk-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-zk-token-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-frozen-abi" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-frozen-abi-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }
+"solana-transaction-status" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.23-enforce-cpi-tracking" }


### PR DESCRIPTION
Update from `1.18.22` to `1.18.23` is a minor version upgrade, which gets pulled for all new projects. To avoid issues with `TestIndexer`, bump the patched Agave libraries to 1.18.23.