### PR TITLE
chore: Remove unnecessary patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,8 @@ codegen-units = 1
 "solana-banks-interface" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
 "solana-banks-server" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
 "solana-program" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-cli-output" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
 "solana-program-test" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
 "solana-program-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
-"solana-rpc" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
 "solana-rpc-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
 "solana-rpc-client-api" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }
 "solana-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }


### PR DESCRIPTION
solana-cli-output and solana-rpc are not actually used as dependencies. That makes Cargo confused, triggers warnings and causes other patches to not be actually applied[0].

[0] That's an unexpected behavior and it'd be great to investigate
    it further. For now, removing redundant deps solves all the
    issues.